### PR TITLE
fix: Do not require auth on CORS preflights

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateCredentialsFilter.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/files/generateCredentialsFilter.mtl
@@ -119,16 +119,27 @@ public class [anAdaptorInterface.javaClassNameForCredentialsFilter() /] implemen
      * @return true - the resource is protected, otherwise false
      */
     private boolean isProtectedResource(HttpServletRequest httpRequest) {
-        if (ignoreResourceProtection) {
-            return false;
-        }
         String pathInfo = httpRequest.getPathInfo();
 
         //'protectedResource' defines the basic set of requests that needs to be protected. 
         //You can override this defintion in the user protected code block below.
+        // Do not protect OSLC resources needed for initial discovery
         boolean protectedResource = !pathInfo.startsWith("/rootservices") && !pathInfo.startsWith("/oauth");
+        // Do not protect CORS preflight requests
+        if (protectedResource) {
+            String method = httpRequest.getMethod();
+            if ("OPTIONS".equalsIgnoreCase(method)) {
+                protectedResource = false;
+            }
+        }
+        // Only for debugging!
+        if (ignoreResourceProtection) {
+            protectedResource = false;
+        }
+        // Here you can override or extend the checks
         // [protected ('isProtectedResource')]
         // [/protected]
+
         return protectedResource;
     }
 


### PR DESCRIPTION
## Description

Do not require auth on CORS preflights. Also allows the ignore flag to be overridden too.

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [ ] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [ ] This PR does NOT break the user block code


## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
