### PR TITLE
feat: migrate to Bootstrap 5

### DIFF
--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
@@ -89,7 +89,9 @@
 
   <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
   <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
+    document.addEventListener('DOMContentLoaded', function() {
+      setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));
+    });
   </script>
 </head>
 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceJsp.mtl
@@ -89,7 +89,7 @@
 
   <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
   <script type="text/javascript">
-    $(function () {setupUiPreviewOnPopover($("a.oslc-resource-link"));});
+    document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
   </script>
 </head>
 
@@ -98,7 +98,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(contextAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>
@@ -132,7 +132,7 @@
           [for (aProperty: ResourceProperty | propertiesCollection)]
           <dl class="row">
             <% method = [javaClassName(aResource)/].class.getMethod("[javaAttributeGetterMethodName(aProperty, aResource)/]"); %>
-            <dt  class="col-sm-2 text-right"><a href="<%=method.getAnnotation(OslcPropertyDefinition.class).value() %>"><%=method.getAnnotation(OslcName.class).value()%></a></dt>
+            <dt  class="col-sm-2 text-end"><a href="<%=method.getAnnotation(OslcPropertyDefinition.class).value() %>"><%=method.getAnnotation(OslcName.class).value()%></a></dt>
             <dd class="col-sm-9">
             [propertyToHtml(aProperty, aResource, 'a'.concat(javaName(aResource, true)), contextAdaptorInterface) /]
             </dd>
@@ -153,7 +153,7 @@
                 Object value = entry.getValue();
             %>
             <dl class="row">
-                <dt  class="col-sm-2 text-right"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
+                <dt  class="col-sm-2 text-end"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
                 <dd class="col-sm-9"><%= value.toString()%></dd>
             </dl>
             <%

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceLargePreviewJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceLargePreviewJsp.mtl
@@ -115,7 +115,7 @@ if (!extendedProperties.isEmpty()) {
         Object value = entry.getValue();
     %>
     <dl class="row">
-        <dt  class="col-sm-2 text-right"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
+        <dt  class="col-sm-2 text-end"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
         <dd class="col-sm-9"><%= value.toString()%></dd>
     </dl>
     <%

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceSmallPreviewJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceSmallPreviewJsp.mtl
@@ -115,7 +115,7 @@ if (!extendedProperties.isEmpty()) {
         Object value = entry.getValue();
     %>
     <dl class="row">
-        <dt  class="col-sm-2 text-right"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
+        <dt  class="col-sm-2 text-end"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
         <dd class="col-sm-9"><%= value.toString()%></dd>
     </dl>
     <%

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceViewForOslcUIJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateGetResourceViewForOslcUIJsp.mtl
@@ -92,7 +92,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(contextAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>
@@ -111,16 +111,16 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-2 text-right">
-                <p class="font-weight-bold">Resource URI</p>
+            <div class="col-2 text-end">
+                <p class="fw-bold">Resource URI</p>
             </div>
             <div class="col">
                 <a href="<%=aResource.getAbout() %>" class="text-monospace"><%=aResource.getAbout()%></a>
             </div>
         </div>
         <div class="row">
-            <div class="col-2 text-right">
-                <p class="font-weight-bold">OSLC Shape</p>
+            <div class="col-2 text-end">
+                <p class="fw-bold">OSLC Shape</p>
             </div>
             <div class="col">
                 <p class="text-monospace">
@@ -129,8 +129,8 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-2 text-right">
-                <p class="font-weight-bold">Additional RDF Types</p>
+            <div class="col-2 text-end">
+                <p class="fw-bold">Additional RDF Types</p>
             </div>
             <div class="col">
                 <ul class="list-unstyled">
@@ -178,7 +178,7 @@
                 Object value = entry.getValue();
             %>
             <dl class="row">
-                <dt  class="col-sm-2 text-right"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
+                <dt  class="col-sm-2 text-end"><a href="<%=key.getNamespaceURI() + key.getLocalPart() %>"><%=key.getLocalPart()%></a></dt>
                 <dd class="col-sm-9"><%= value.toString()%></dd>
             </dl>
             <%
@@ -208,16 +208,16 @@
         var largePrev = compactStructure.large;
         if (smallPrev !== null) {
             smallUiPreview.onclick = function(){ 
-                $(largeUiPreview).removeClass("active");
-                $(smallUiPreview).addClass("active");
+                largeUiPreview.classList.remove("active");
+                smallUiPreview.classList.add("active");
                 showPreview(smallPrev); 
                 return false; 
             };
         }
         if (largePrev !== null) {
             largeUiPreview.onclick = function(){ 
-                $(smallUiPreview).removeClass("active");
-                $(largeUiPreview).addClass("active");
+                smallUiPreview.classList.remove("active");
+                largeUiPreview.classList.add("active");
                 showPreview(largePrev); 
                 return false; 
             };
@@ -238,7 +238,7 @@
             divForUiPreviewIframe.appendChild(previewIframe);
         }
         else {
-            $(divForUiPreviewIframe).children().replaceWith(previewIframe);
+            divForUiPreviewIframe.replaceChildren(previewIframe);
         }
     }
     

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
@@ -75,7 +75,9 @@
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
   <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
   <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
+    document.addEventListener('DOMContentLoaded', function() {
+      setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));
+    });
   </script>
 
 </head>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCollectionJsp.mtl
@@ -75,7 +75,7 @@
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
   <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
   <script type="text/javascript">
-    $(function () {setupUiPreviewOnPopover($("a.oslc-resource-link"));});
+    document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
   </script>
 
 </head>
@@ -84,7 +84,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(anAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCreatorClientJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceCreatorClientJsp.mtl
@@ -71,7 +71,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(anAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>
@@ -121,7 +121,7 @@
 </footer>
 
 <script type="text/javascript">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function() {
         registerCreationDUIResponseListener(document.getElementById("delegatedUI"), resetPreviousCreation, presentOslcCreation);
 
         function presentOslcCreation(resourceUrl, resourceLabel) {
@@ -135,7 +135,7 @@
             var li = document.createElement("LI");
             li.appendChild(hyperlinkElement); 
             document.querySelector('#results ul').appendChild(li);
-            setupUiPreviewOnPopover($("a.oslc-resource-link"));
+            setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));
         }
 
         function resetPreviousCreation() {

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceSelectorClientJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceSelectorClientJsp.mtl
@@ -69,7 +69,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(anAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>
@@ -119,7 +119,7 @@
 </footer>
 
 <script type="text/javascript">
-    $(function () {
+    document.addEventListener('DOMContentLoaded', function() {
         registerSelectionDUIResponseListener(document.getElementById("delegatedUI"), resetPreviousSelections, presentOslcSelection);
 
         function presentOslcSelection(resourceUrl, resourceLabel) {
@@ -133,7 +133,7 @@
             var li = document.createElement("LI");
             li.appendChild(hyperlinkElement); 
             document.querySelector('#results ul').appendChild(li);
-            setupUiPreviewOnPopover($("a.oslc-resource-link"));
+            setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));
         }
 
         function resetPreviousSelections() {

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
@@ -68,7 +68,9 @@
         <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
         <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
         <script type="text/javascript">
-            document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
+            document.addEventListener('DOMContentLoaded', function() {
+                setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));
+            });
         </script>
     </head>
     <body>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateResourceShapeJsp.mtl
@@ -68,7 +68,7 @@
         <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
         <script src="<c:url value="/static/js/ui-preview-helper.js"/>"></script>
         <script type="text/javascript">
-            $(function () {setupUiPreviewOnPopover($("a.oslc-resource-link"));});
+            document.addEventListener('DOMContentLoaded', function() {setupUiPreviewOnPopover(document.querySelectorAll("a.oslc-resource-link"));});
         </script>
     </head>
     <body>
@@ -76,7 +76,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(anAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderCatalogHTML.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderCatalogHTML.mtl
@@ -70,7 +70,7 @@ String catalogUrl = UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("/catal
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[containingAdaptorInterface(aServiceProviderCatalog).swaggerIndexJspRelativeFileName()/]"/>">Swagger UI</a></li>
       </ul>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderHTML.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateServiceProviderHTML.mtl
@@ -76,7 +76,7 @@ String catalogUrl = UriBuilder.fromUri(OSLC4JUtils.getServletURI()).path("/catal
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="<%= catalogUrl %>"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[containingAdaptorInterface(aServiceProvider).swaggerIndexJspRelativeFileName()/]"/>">Swagger UI</a></li>
       </ul>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateSwaggerIndexJsp.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/jsp/generateSwaggerIndexJsp.mtl
@@ -86,7 +86,7 @@
   <nav class="navbar navbar-expand-lg sticky-top navbar-light bg-light">
     <div class="container">
       <a class="navbar-brand" href="<c:url value="/"/>"><%= application.getServletContextName() %></a>
-      <ul class="navbar-nav mr-auto">
+      <ul class="navbar-nav me-auto">
         <li class="nav-item"><a class="nav-link" href="<c:url value="/services/catalog/singleton"/>">Service Provider Catalog</a></li>
         <li class="nav-item"><a class="nav-link" href="<c:url value="[swaggerIndexJspRelativeFileName(anAdaptorInterface)/]"/>">Swagger UI</a></li>
       </ul>

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/jspServices.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/services/jspServices.mtl
@@ -23,10 +23,9 @@
 [import org::eclipse::lyo::oslc4j::codegenerator::services::fileServices/]
 
 [template public generateBootstrapTags(traceabilityContext : OclAny)]
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous">
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js" integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k" crossorigin="anonymous"></script>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossorigin="anonymous"></script>
 [/template]
 
 [query public generateJspFile(anAdaptorInterface : AdaptorInterface, filePath : String) : Boolean = 

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
@@ -40,80 +40,134 @@
 
 //Setup a popover on each of the oslcLinkElements, where the popover content is an iframe presenting the OSLC UI-Preview.
 function setupUiPreviewOnPopover(oslcLinkElements) {
-  // Destroy any existing popovers first
-  oslcLinkElements.popover('dispose');
+  // Convert NodeList to Array if needed
+  const elements = Array.from(oslcLinkElements);
 
-  // Initialize popovers with improved settings
-  oslcLinkElements.popover({
-    container: "body",
-    content: "Loading...",
-    delay: {
-      "show": 120,
-      "hide": 200  // Increased hide delay to reduce flickering
-    },
-    html: true,
-    placement: "auto",
-    trigger: "hover",
-    boundary: 'window',  // Ensures proper positioning relative to viewport
-    popperConfig: {
-      modifiers: {
-        preventOverflow: {
-          boundariesElement: 'viewport'
-        }
-      }
+  // Destroy any existing popovers first
+  elements.forEach(element => {
+    const existingPopover = bootstrap.Popover.getInstance(element);
+    if (existingPopover) {
+      existingPopover.dispose();
     }
   });
 
-  // Add CSS to prevent pointer events on popover
-  $("<style>")
-    .prop("type", "text/css")
-    .html(`
-                .popover {
-                    pointer-events: none;
-                }
-                .popover-body {
-                    pointer-events: auto;
-                }
-            `)
-    .appendTo("head");
+  // Add CSS to improve popover styling and ensure proper sizing
+  if (!document.getElementById('ui-preview-styles')) {
+    const style = document.createElement('style');
+    style.id = 'ui-preview-styles';
+    style.textContent = `
+      .ui-preview-popover {
+        pointer-events: auto;
+        max-width: 90vw;
+        width: 600px;
+        height: auto;
+        z-index: 1070;
+      }
+      .ui-preview-popover .popover-header {
+        background-color: #f8f9fa;
+        border-bottom: 1px solid #dee2e6;
+        font-weight: 600;
+        padding: 8px 12px;
+        margin: 0;
+        display: block !important;
+        flex-shrink: 0;
+      }
+      .ui-preview-popover .popover-body {
+        pointer-events: auto;
+        padding: 8px;
+        height: 450px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .ui-preview-popover .popover-body iframe {
+        border: none;
+        width: 100%;
+        height: 100%;
+        min-height: 400px;
+        display: block;
+        flex: 1;
+        border-radius: 4px;
+      }
+      .ui-preview-popover .popover-arrow {
+        position: absolute;
+      }
+      a.oslc-resource-link:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    `;
+    document.head.appendChild(style);
+  }
 
-  // Modified event handler with debouncing
-  let loadingTimeout;
-  oslcLinkElements.on("show.bs.popover", function (e) {
-    const uiElem = $(this);
-    const popoverElem = uiElem.data('bs.popover');
+  // Initialize Bootstrap 5 popovers
+  elements.forEach(element => {
+    const popover = new bootstrap.Popover(element, {
+      container: document.body,
+      content: 'Loading...',
+      html: true,
+      placement: 'auto',
+      trigger: 'hover focus',
+      delay: { show: 150, hide: 100 },
+      customClass: 'ui-preview-popover',
+      sanitize: false, // Allow iframe content
+      fallbackPlacements: ['['top', 'bottom', 'left', 'right'[']']
+    });
 
-    // Clear any pending loading timeout
-    clearTimeout(loadingTimeout);
+    // Event handlers for Bootstrap 5
+    element.addEventListener('show.bs.popover', function() {
+      const href = this.getAttribute('href');
+      if (href) {
+        getUiPreviewIframes(href, attachIframeToHyperlinkElement, {
+          element: element,
+          popover: popover
+        });
+      }
+    });
 
-    // Set new timeout for loading
-    loadingTimeout = setTimeout(() => {
-      getUiPreviewIframes(
-        this.getAttribute("href"),
-        attachIframeToHyperlinkElement,
-        uiElem
-      );
-    }, 50);  // Small delay to prevent multiple rapid loads
-  });
-
-  // Clean up on hide
-  oslcLinkElements.on("hide.bs.popover", function () {
-    clearTimeout(loadingTimeout);
+    element.addEventListener('shown.bs.popover', function() {
+      // Ensure popover is properly positioned after content loads
+      popover.update();
+    });
   });
 }
 
-function attachIframeToHyperlinkElement(compactStructure, uiElem) {
-  uiElem.attr('data-original-title', compactStructure.title);
-  var preview = compactStructure.small;
-  var w = preview.width ? preview.width : "450em";
-  var h = preview.height ? preview.height : "100em";
-  var w = '100%';
-  var h = '100%';
-  var iframeHtml = "<iframe src='" + preview.uri + "' ";
-  iframeHtml += " style='border:0px; height:" + h + "; width:" + w + "; overflow: hidden'";
-  iframeHtml += "></iframe>";
-  uiElem.attr('data-content', iframeHtml);
-  uiElem.data('bs.popover').setContent();
+function attachIframeToHyperlinkElement(compactStructure, params) {
+  const { element, popover } = params;
+  
+  if (compactStructure === "Error") {
+    element.setAttribute('data-bs-original-title', 'Error loading preview');
+    element.setAttribute('data-bs-content', '<p class="text-danger">Unable to load preview</p>');
+    popover.setContent({
+      '.popover-header': 'Error',
+      '.popover-body': '<p class="text-danger">Unable to load preview</p>'
+    });
+    return;
+  }
+
+  const title = compactStructure.title || 'Resource Preview';
+  const preview = compactStructure.small || compactStructure.large;
+  
+  if (!preview || !preview.uri) {
+    element.setAttribute('data-bs-original-title', title);
+    element.setAttribute('data-bs-content', '<p class="text-muted">No preview available</p>');
+    popover.setContent({
+      '.popover-header': title,
+      '.popover-body': '<p class="text-muted">No preview available</p>'
+    });
+    return;
+  }
+
+  const iframeHtml = `<iframe src="${preview.uri}" style="border: 0; width: 100%; height: 100%; min-height: 400px;" sandbox="allow-same-origin allow-scripts allow-forms allow-popups"></iframe>`;
+  
+  element.setAttribute('data-bs-original-title', title);
+  element.setAttribute('data-bs-content', iframeHtml);
+  
+  // Update popover content
+  popover.setContent({
+    '.popover-header': title,
+    '.popover-body': iframeHtml
+  });
 }
 
 //Perform an asynch GET request to obtain the resource's UI-Preview information (an OSLC Compact resource).

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
@@ -111,7 +111,7 @@ function setupUiPreviewOnPopover(oslcLinkElements) {
       delay: { show: 150, hide: 100 },
       customClass: 'ui-preview-popover',
       sanitize: false, // Allow iframe content
-      fallbackPlacements: ['['top', 'bottom', 'left', 'right'[']']
+      fallbackPlacements: ['['/]'top', 'bottom', 'left', 'right'[']'/]
     });
 
     // Event handlers for Bootstrap 5

--- a/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
+++ b/org.eclipse.lyo.oslc4j.codegenerator/src/org/eclipse/lyo/oslc4j/codegenerator/staticFiles/generateUiPreviewHelperJs.mtl
@@ -89,85 +89,126 @@ function setupUiPreviewOnPopover(oslcLinkElements) {
         flex: 1;
         border-radius: 4px;
       }
-      .ui-preview-popover .popover-arrow {
-        position: absolute;
-      }
-      a.oslc-resource-link:hover {
-        text-decoration: underline;
-        cursor: pointer;
-      }
     `;
     document.head.appendChild(style);
   }
 
-  // Initialize Bootstrap 5 popovers
+ // Initialize Bootstrap 5 popovers
   elements.forEach(element => {
+    let loadingTimeout;
+    let hideTimeout;
+    let isPopoverShown = false;
+    
     const popover = new bootstrap.Popover(element, {
-      container: document.body,
-      content: 'Loading...',
+      container: "body",
+      content: "Loading preview...",
+      title: "Resource Preview",  // Default title that will be replaced
+      delay: {
+        "show": 300,    // Increased show delay to prevent flickering
+        "hide": 0       // No automatic hide delay - we'll handle it manually
+      },
       html: true,
-      placement: 'auto',
-      trigger: 'hover focus',
-      delay: { show: 150, hide: 100 },
-      customClass: 'ui-preview-popover',
-      sanitize: false, // Allow iframe content
-      fallbackPlacements: ['['/]'top', 'bottom', 'left', 'right'[']'/]
+      placement: "auto",
+      trigger: "manual",  // Use manual trigger to have better control
+      boundary: 'viewport',
+      customClass: 'ui-preview-popover'
     });
 
-    // Event handlers for Bootstrap 5
-    element.addEventListener('show.bs.popover', function() {
-      const href = this.getAttribute('href');
-      if (href) {
-        getUiPreviewIframes(href, attachIframeToHyperlinkElement, {
-          element: element,
-          popover: popover
-        });
-      }
-    });
+    // Function to show popover
+    const showPopover = () => {
+      if (isPopoverShown) return;
+      
+      clearTimeout(loadingTimeout);
+      clearTimeout(hideTimeout);
+      
+      loadingTimeout = setTimeout(() => {
+        if (!isPopoverShown) {
+          popover.show();
+          isPopoverShown = true;
+          
+          // Set up popover hover handlers after it's shown
+          setTimeout(() => {
+            const popoverElement = document.querySelector('.popover.ui-preview-popover');
+            if (popoverElement) {
+              popoverElement.addEventListener('mouseenter', () => {
+                clearTimeout(hideTimeout);
+              });
+              
+              popoverElement.addEventListener('mouseleave', () => {
+                hidePopover();
+              });
+            }
+          }, 10);
+          
+          // Load content after showing
+          getUiPreviewIframes(
+            element.getAttribute("href"),
+            attachIframeToHyperlinkElement,
+            element
+          );
+        }
+      }, 300);
+    };
 
-    element.addEventListener('shown.bs.popover', function() {
-      // Ensure popover is properly positioned after content loads
-      popover.update();
-    });
+    // Function to hide popover
+    const hidePopover = () => {
+      clearTimeout(loadingTimeout);
+      clearTimeout(hideTimeout);
+      
+      hideTimeout = setTimeout(() => {
+        if (isPopoverShown) {
+          popover.hide();
+          isPopoverShown = false;
+        }
+      }, 200);  // Small delay to allow mouse movement to popover
+    };
+
+    // Mouse enter handler for the link
+    element.addEventListener("mouseenter", showPopover);
+
+    // Mouse leave handler for the link
+    element.addEventListener("mouseleave", hidePopover);
+
+    // Allow normal click behavior - don't prevent default when popover is shown
+    // This allows users to click through to the resource even if popover is open
   });
 }
 
-function attachIframeToHyperlinkElement(compactStructure, params) {
-  const { element, popover } = params;
+function attachIframeToHyperlinkElement(compactStructure, uiElem) {
+  var preview = compactStructure.small;
   
-  if (compactStructure === "Error") {
-    element.setAttribute('data-bs-original-title', 'Error loading preview');
-    element.setAttribute('data-bs-content', '<p class="text-danger">Unable to load preview</p>');
-    popover.setContent({
-      '.popover-header': 'Error',
-      '.popover-body': '<p class="text-danger">Unable to load preview</p>'
-    });
-    return;
-  }
+  // Create iframe with fixed dimensions that work well in the popover
+  var iframeHtml = "<iframe src='" + preview.uri + "' ";
+  iframeHtml += " style='border: none; width: 100%; height: 100%; display: block;'";
+  iframeHtml += " title='Resource Preview'></iframe>";
 
-  const title = compactStructure.title || 'Resource Preview';
-  const preview = compactStructure.small || compactStructure.large;
-  
-  if (!preview || !preview.uri) {
-    element.setAttribute('data-bs-original-title', title);
-    element.setAttribute('data-bs-content', '<p class="text-muted">No preview available</p>');
-    popover.setContent({
-      '.popover-header': title,
-      '.popover-body': '<p class="text-muted">No preview available</p>'
-    });
-    return;
-  }
+  // Get the Bootstrap 5 popover instance and update content
+  const popoverInstance = bootstrap.Popover.getInstance(uiElem);
+  if (popoverInstance) {
+    // Update the popover configuration with new content and title
+    popoverInstance._config.content = iframeHtml;
+    popoverInstance._config.title = compactStructure.title || "Resource Preview";
 
-  const iframeHtml = `<iframe src="${preview.uri}" style="border: 0; width: 100%; height: 100%; min-height: 400px;" sandbox="allow-same-origin allow-scripts allow-forms allow-popups"></iframe>`;
-  
-  element.setAttribute('data-bs-original-title', title);
-  element.setAttribute('data-bs-content', iframeHtml);
-  
-  // Update popover content
-  popover.setContent({
-    '.popover-header': title,
-    '.popover-body': iframeHtml
-  });
+    // If popover is currently shown, update its content immediately
+    const popoverElement = document.querySelector('.popover.ui-preview-popover');
+    if (popoverElement) {
+      const popoverBody = popoverElement.querySelector('.popover-body');
+      if (popoverBody) {
+        popoverBody.innerHTML = iframeHtml;
+      }
+      
+      // Ensure header is visible and properly styled
+      let popoverHeader = popoverElement.querySelector('.popover-header');
+      if (!popoverHeader) {
+        // Create header if it doesn't exist
+        popoverHeader = document.createElement('div');
+        popoverHeader.className = 'popover-header';
+        popoverElement.insertBefore(popoverHeader, popoverBody);
+      }
+      popoverHeader.textContent = compactStructure.title || "Resource Preview";
+      popoverHeader.style.display = 'block';
+    }
+  }
 }
 
 //Perform an asynch GET request to obtain the resource's UI-Preview information (an OSLC Compact resource).


### PR DESCRIPTION
## Description

- Removes dependency on jQuery
- Updates various CSS classes for Bootstrap 5
- Fixes many issues around popover

## Checklist

- [ ] This PR adds an entry to the CHANGELOG. _See https://keepachangelog.com/en/1.0.0/ for instructions. Minor edits are exempt. 
- [ ] This PR expects some manual changes to the generated code. The needed changes are detailed in the CHANGELOG entry.
- [ ] This PR was tested with at least one code generation, resulting in a working OSLC server.
- [ ] This PR does NOT break the user block code


## Issues

Closes #0; Closes #00

_(use exactly this syntax to link to issues, one issue per statement only!)_
